### PR TITLE
nickelchicken collides with lime chicken

### DIFF
--- a/src/main/java/com/gendeathrow/morechickens/modHelper/BaseMetalsAddon.java
+++ b/src/main/java/com/gendeathrow/morechickens/modHelper/BaseMetalsAddon.java
@@ -303,14 +303,14 @@ public class BaseMetalsAddon extends BaseModAddon
 		setParents(copperChicken, YellowChicken, BrownChicken);
 		setParents(leadChicken, IronChicken, CyanChicken);
 		setParents(tinChicken, WhiteChicken, ClayChicken);
-		setParents(nickelChicken, WhiteChicken, GreenChicken);
+		setParents(nickelChicken, silverOreChicken, GreenChicken);
 		setParents(zincChicken, WhiteChicken, ClayChicken);
 		setParents(silverOreChicken, IronChicken, WhiteChicken);
 		setParents(platinumChicken, nickelChicken, silverOreChicken);
 		setParents(sulfurChicken, GunpowderChicken, FlintChicken);
 		setParents(saltpeterChicken, sulfurChicken, RedstoneChicken);
 		setParents(siliconChicken, ClayChicken, SandChicken);
-		setParents(aluminumChicken, FlintChicken, IronChicken);	
+		setParents(aluminumChicken, FlintChicken, IronChicken);
 		setParents(amberChicken, WaterChicken, LogChicken);
 		setParents(amethystChicken, GhastChicken, PurpleChicken);
 		if(this.getFirstOreDictionary("ingotCopper") != null)


### PR DESCRIPTION
the lime chicken has the breeding of:
white + green set here (2 years ago):
https://github.com/setycz/ChickensMod/blob/03497fec4a08f156f8b448db76316985f5fe0ebd/src/main/java/com/setycz/chickens/ChickensMod.java

whereas the nickelchicken has the breeding of:
white + green

i'd suggest another combo, like silver + green to make it work.

i am no java programmer tho, nor a modder. thus the "fix" might be incomplete. I am just assuming this is the correct place.


best regards