### PR TITLE
update maven domain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ minecraft {
 repositories {
     maven { // Hwyla (Waila updated for 1.10)
         name "TehNut Maven"
-        url "http://tehnut.info/maven/"
+        url "https://maven.tehnut.info/"
     }
     maven { // JEI
         name = "Progwml6 Maven"


### PR DESCRIPTION
changed to https://maven.tehnut.info/

The HWYLA_version needs to be updated in gradle.properties. Problem is that I can't find MC 1.12 version for Hwyla on maven. Only 1.12.2 (1.8.26-B41_1.12.2)